### PR TITLE
Use copy() to prevent modifying original data.table

### DIFF
--- a/R/000-FunctionDefs.R
+++ b/R/000-FunctionDefs.R
@@ -136,6 +136,7 @@ Calculate_OwnedDurableItemsDepreciation <- function(DurableData_ExpDetail,
 
 CalcTornqvistIndex <- function(DataTable){
   #DataTable <- SMD
+  DataTable <- copy(DataTable)
   DataTable <- DataTable[,MeterPrice:=ifelse(tenure=="Free"|tenure=="Other"|tenure=="AgainstService"
                                              ,NA,MeterPrice)]
   DataTable <- DataTable[,House_Exp:=ifelse(tenure=="Free"|tenure=="Other"|tenure=="AgainstService"


### PR DESCRIPTION
## Problem
The `CalcTornqvistIndex` function currently modifies the input `DataTable` directly since `data.table` uses reference semantics. This leads to unintended changes to `House_Exp` and derived total consumption/expenditure values in the original data. (#7)

## Solution
Create a copy of `DataTable` at the start of the function to ensure modifications don't affect the original data.

```R
CalcTornqvistIndex <- function(DataTable) {
  # Create copy to avoid modifying original data
  DataTable <- copy(DataTable)
  
  DataTable <- DataTable[,MeterPrice:=ifelse(tenure=="Free"|tenure=="Other"|tenure=="AgainstService"
                                           ,NA,MeterPrice)]
  # Rest of function...
}
```